### PR TITLE
model_module.py

### DIFF
--- a/python/particle_tracking/model_module.py
+++ b/python/particle_tracking/model_module.py
@@ -263,7 +263,7 @@ def modelinterpolants(tt,model):
         a = dss.rho.interp(x=dss.x,y=dss.y,z=-10) 
         
         # find density at 10m + 0.03
-        avalues = np.repeat(a.values[:,:,np.newaxis]+0.03,50,axis=2)
+        avalues = np.repeat(a.values[:,:,np.newaxis]+0.03,66,axis=2)
         
         # prepare arrays
         zz,yy,xx = np.meshgrid(dss.z,dss.y,dss.x,indexing='ij')   


### PR DESCRIPTION
My output files have 66 vertical levels and you had written 50 at line 266. Because of that it was unable  to do the comparison at 272 and 273 due to different shapes.
I do not know if the vertical levels vary depending the model output. If that is the case that value should be not hardcoded, right?